### PR TITLE
enable a blocksize parameter

### DIFF
--- a/com.ibm.streamsx.hdfs/com.ibm.streamsx.hdfs/HDFS2FileSink/HDFS2FileSink.xml
+++ b/com.ibm.streamsx.hdfs/com.ibm.streamsx.hdfs/HDFS2FileSink/HDFS2FileSink.xml
@@ -283,6 +283,7 @@ The output port is non-mutating and its punctuation mode is `Free`.
 The schema of the output port is &lt;string fileName, uint64 fileSize&gt;, which specifies the name and size of files that are written to HDFS.</description>
         <windowPunctuationOutputMode>Free</windowPunctuationOutputMode>
         <windowPunctuationInputPort>-1</windowPunctuationInputPort>
+	<finalPunctuationPortScope/>
         <cardinality>1</cardinality>
         <optional>true</optional>
       </outputPortSet>

--- a/com.ibm.streamsx.hdfs/com.ibm.streamsx.hdfs/HDFS2FileSource/HDFS2FileSource.xml
+++ b/com.ibm.streamsx.hdfs/com.ibm.streamsx.hdfs/HDFS2FileSource/HDFS2FileSource.xml
@@ -121,6 +121,14 @@ If the optional input port is used and the file name is specified, the operator 
         <cardinality>1</cardinality>
       </parameter>
       <parameter>
+        <name>blockSize</name>
+        <description>
+This parameter specifies the maximum number of bytes to be read at one time when reading a file into binary mode (ie, into a blob); thus, it is the maximum size of the blobs on the output stream. The parameter is optional, and defaults to `4096`.</description>
+        <optional>true</optional>
+        <type>int32</type>
+        <cardinality>1</cardinality>
+      </parameter>
+      <parameter>
         <name>initDelay</name>
         <description sampleUri="">
 This parameter specifies the time to wait in seconds before the operator reads the first file.  

--- a/com.ibm.streamsx.hdfs/impl/java/src/com/ibm/streamsx/hdfs/HDFS2FileSource.java
+++ b/com.ibm.streamsx.hdfs/impl/java/src/com/ibm/streamsx/hdfs/HDFS2FileSource.java
@@ -57,12 +57,12 @@ public class HDFS2FileSource extends AbstractHdfsOperator {
 
 	private String encoding = "UTF-8";
 
-	/*
-	@Parameter(name=BLOCKSIZE_PARAM,description="The maximum number of bytes to read into a blob.   Defaults to 4096 bytes")
+	
+    @Parameter(name=BLOCKSIZE_PARAM,optional=true,description="This parameter specifies the maximum number of bytes to be read at one time when reading a file into binary mode (ie, into a blob).  It its optional, and defaults to `4096`.")
 	public void setBlockSize (int inBlockSize) {
 		blockSize = inBlockSize;
 	}
-	*/
+	
 	
 	@Override
 	public synchronized void initialize(OperatorContext context)


### PR DESCRIPTION
Allow blocksize ot be a parameter.  Fixes #34.  

It also sets the finalPunctuationPortScope to empty for the HDFS2FileSink output port. This solves #35 , but it also means that HDFS2FileSink will not shut itself down on a final punctuation, so apps using HDFS2FileSink in standalone mode won't terminate.  So, you may want me to undo this before pulling it in.  