### PR TITLE
Fix samples toolkit path issue #44

### DIFF
--- a/samples/CompressedHdfsFiles/Makefile
+++ b/samples/CompressedHdfsFiles/Makefile
@@ -10,10 +10,10 @@ SPLC_FLAGS = -a -z -t ../../com.ibm.streamsx.hdfs:$(STREAMS_INSTALL)/toolkits/co
 SPLC = $(STREAMS_INSTALL)/bin/sc
 
 SPL_CMD_ARGS ?=
-SPL_COMP1NAME=ScanAndRead
-SPL_COMP2NAME=ScanAndReadWithInputPort
-SPL_MAIN_COMPOSITE1 = hdfsexample::$(SPL_COMP1NAME)
-SPL_MAIN_COMPOSITE2 = hdfsexample::$(SPL_COMP2NAME)
+SPL_COMP1NAME=Read
+SPL_COMP2NAME=Write
+SPL_MAIN_COMPOSITE1 = com.ibm.streamsx.hdfs.sample::$(SPL_COMP1NAME)
+SPL_MAIN_COMPOSITE2 = com.ibm.streamsx.hdfs.sample::$(SPL_COMP2NAME)
 STANDALONE_OUTPUT_DIR = output/Standalone
 DISTRIBUTED_OUTPUT_DIR = output/Distributed
 

--- a/samples/HDFSFileSinkSamples/Makefile
+++ b/samples/HDFSFileSinkSamples/Makefile
@@ -5,7 +5,7 @@
 
 .PHONY: all clean
 
-STREAMS_SPLPATH ?=$(STREAMS_INSTALL)/toolkits/com.ibm.streamsx.hdfs
+STREAMS_SPLPATH ?=../../com.ibm.streamsx.hdfs:$(STREAMS_INSTALL)/toolkits/com.ibm.streamsx.hdfs
 SPLC_FLAGS = -a -z --spl-path $(STREAMS_SPLPATH)
 
 SPLC = $(STREAMS_INSTALL)/bin/sc

--- a/samples/HDFSFileSourceSamples/Makefile
+++ b/samples/HDFSFileSourceSamples/Makefile
@@ -5,7 +5,7 @@
                             
 .PHONY: all clean
  
-SPLC_FLAGS = -a -z -t $(STREAMS_INSTALL)/toolkits/com.ibm.streamsx.hdfs
+SPLC_FLAGS = -a -z -t ../../com.ibm.streamsx.hdfs:$(STREAMS_INSTALL)/toolkits/com.ibm.streamsx.hdfs
 
 SPLC = $(STREAMS_INSTALL)/bin/sc
 


### PR DESCRIPTION
1. Added missing Makefile for CompressedHdfsFiles
2. Added ../../com.ibm.streamsx.hdfs to the toolkit path.