### PR TITLE
fix kerberos auth

### DIFF
--- a/com.ibm.streamsx.hdfs/impl/java/src/com/ibm/streamsx/hdfs/client/auth/BaseAuthenticationHelper.java
+++ b/com.ibm.streamsx.hdfs/impl/java/src/com/ibm/streamsx/hdfs/client/auth/BaseAuthenticationHelper.java
@@ -92,6 +92,7 @@ public abstract class BaseAuthenticationHelper implements IAuthenticationHelper 
 	protected UserGroupInformation authenticateWithKerberos(final String hdfsUser,
 			final String kerberosPrincipal, final String kerberosKeytab)
 			throws Exception {
+		UserGroupInformation.setConfiguration(fConfiguration);
 		UserGroupInformation ugi;
 		if (HDFSOperatorUtils.isValidHdfsUser(hdfsUser)) {
 			UserGroupInformation.loginUserFromKeytab(kerberosPrincipal,


### PR DESCRIPTION
Without this fix, the `UserGroupInformation` will use default `core-site.xml` in `$HADOOP_HOME` instead of the file specified by `configPath`. This issue will cause failed auth.